### PR TITLE
Set cwd to project root and handle errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,15 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "10.12.21",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.21.tgz",
-			"integrity": "sha512-CBgLNk4o3XMnqMc0rhb6lc77IwShMEglz05deDcn2lQxyXEZivfwgYJu7SMha9V5XcrP6qZuevTHV/QrN2vjKQ==",
+			"version": "10.14.12",
+			"resolved": "https://unpm.uberinternal.com/@types%2fnode/-/node-10.14.12.tgz",
+			"integrity": "sha512-QcAKpaO6nhHLlxWBvpc4WeLrTvPqlHOvaj0s5GriKkA1zq+bsFBPpfYCvQhLqLgYlIko8A9YrPdaMHCo5mBcpg==",
 			"dev": true
+		},
+		"@types/vscode": {
+			"version": "1.36.0",
+			"resolved": "https://unpm.uberinternal.com/@types%2fvscode/-/vscode-1.36.0.tgz",
+			"integrity": "sha512-SbHR3Q5g/C3N+Ila3KrRf1rSZiyHxWdOZ7X3yFHXzw6HrvRLuVZrxnwEX0lTBMRpH9LkwZdqRTgXW+D075jxkg=="
 		},
 		"ajv": {
 			"version": "6.8.1",

--- a/package.json
+++ b/package.json
@@ -94,10 +94,12 @@
 		"postinstall": "node ./node_modules/vscode/bin/install"
 	},
 	"devDependencies": {
-		"@types/node": "^10.12.21",
 		"@types/mocha": "^5.2.5",
+		"@types/node": "^10.14.12",
 		"typescript": "^3.3.1",
 		"vscode": "^1.1.28"
 	},
-	"dependencies": {}
+	"dependencies": {
+		"@types/vscode": "^1.36.0"
+	}
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -61,7 +61,7 @@ class RunOnSaveExtension {
 			child.stdout.on('data', data => this._outputChannel.append(data));
 			child.stderr.on('data', data => this._outputChannel.append(data));
 			child.on('error', (e) => {
-				this.showOutputMessage(e);
+				this.showOutputMessage(e.message);
 			});
 			child.on('exit', (e) => {
 				// if sync
@@ -82,10 +82,10 @@ class RunOnSaveExtension {
 		}
 	}
 
-	private get _execOption(): {shell: string} {
+	private get _execOption(): {shell: string, cwd: string} {
 		return {
 			shell: this.shell,
-			cwd: vscode.workspace.rootPath
+			cwd: vscode.workspace.rootPath,
 		};
 	}
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -60,6 +60,9 @@ class RunOnSaveExtension {
 			var child = exec(cfg.cmd, this._execOption);
 			child.stdout.on('data', data => this._outputChannel.append(data));
 			child.stderr.on('data', data => this._outputChannel.append(data));
+			child.on('error', (e) => {
+				this.showOutputMessage(e);
+			});
 			child.on('exit', (e) => {
 				// if sync
 				if (!cfg.isAsync) {
@@ -80,9 +83,10 @@ class RunOnSaveExtension {
 	}
 
 	private get _execOption(): {shell: string} {
-		if (this.shell) {
-			return {shell: this.shell};
-		}
+		return {
+			shell: this.shell,
+			cwd: vscode.workspace.rootPath
+		};
 	}
 
 	public get isEnabled(): boolean {


### PR DESCRIPTION
Setting the cwd to the project root allows for doing things like running package.json scripts on file changes. Also adds better error logging for failed commands.