### PR TITLE
Add configuration options for status messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,10 @@ Add "emeraldwalk.runonsave" configuration to user or workspace settings.
   > NOTE Since this is a Regex, and also in a JSON string backslashes have to be double escaped such as when targetting folders. e.g. "match": "some\\\\\\\\folder\\\\\\\\.*"
   * "cmd" - command to run. Can include parameters that will be replaced at runtime (see Placeholder Tokens section below).
   * "isAsync" (optional) - defaults to false. If true, next command will be run before this one finishes.
-
+  * "message" (optional) - message to show when the command is started.
+* "messages" - status messages for the plugin
+  * "running" - message to show when commands are being run.
+  * "done" - message to show when all commands have been run.
 ### Sample Config
 This sample configuration will run echo statements including the saved file path.
 In this sample, the first command is async, so the second command will get executed immediately even if first hasn't completed.

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ Add "emeraldwalk.runonsave" configuration to user or workspace settings.
   * "cmd" - command to run. Can include parameters that will be replaced at runtime (see Placeholder Tokens section below).
   * "isAsync" (optional) - defaults to false. If true, next command will be run before this one finishes.
   * "message" (optional) - message to show when the command is started.
-* "messages" - status messages for the plugin
-  * "running" - message to show when commands are being run.
-  * "done" - message to show when all commands have been run.
+* "messages" (optional) - status messages for the plugin
+  * "running" (optional) - message to show when commands are being run.
+  * "done" (optional) - message to show when all commands have been run.
 ### Sample Config
 This sample configuration will run echo statements including the saved file path.
 In this sample, the first command is async, so the second command will get executed immediately even if first hasn't completed.

--- a/package.json
+++ b/package.json
@@ -55,6 +55,17 @@
 							"type": "string",
 							"description": "Shell to execute the command with (gets passed to child_process.exec as an options arg. e.g. child_process(cmd, { shell })."
 						},
+						"messages": {
+							"type": "object",
+							"running": {
+								"type": "string",
+								"description": "Message to show when Run On Save is executing commands."
+							},
+							"done": {
+								"type": "string",
+								"description": "Message to show when Run On Save is done executing commands."
+							}
+						},
 						"commands": {
 							"type": "array",
 							"items": {

--- a/package.json
+++ b/package.json
@@ -90,6 +90,10 @@
 										"type": "boolean",
 										"description": "Run command asynchronously.",
 										"default": false
+									},
+									"message": {
+										"type": "string",
+										"description": "Message to show when the command is being started."
 									}
 								}
 							}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -32,6 +32,7 @@ interface ICommand {
 	notMatch?: string;
 	cmd: string;
 	isAsync: boolean;
+	message?: string;
 }
 
 interface IConfig {
@@ -66,6 +67,9 @@ class RunOnSaveExtension {
 			var cfg = commands.shift();
 
 			this.showOutputMessage(`*** cmd start: ${cfg.cmd}`);
+			if (cfg.message) {
+				this.showStatusMessage(cfg.message);
+			}
 
 			var child = exec(cfg.cmd, this._getExecOption(document));
 			child.stdout.on('data', data => this._outputChannel.append(data));
@@ -224,7 +228,8 @@ class RunOnSaveExtension {
 
 			commands.push({
 				cmd: cmdStr,
-				isAsync: !!cfg.isAsync
+				isAsync: !!cfg.isAsync,
+				message: cfg.message
 			});
 		}
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -137,8 +137,17 @@ class RunOnSaveExtension {
 		return this._config.commands || [];
 	}
 
-	public get messages(): { running: string, done: string } | undefined {
-		return this._config.messages ?? defaultMessages
+	public get messages(): { running: string, done: string } {
+		const cfgMessages = this._config.messages
+		if (cfgMessages) {
+			return {
+				running: cfgMessages.running ?? defaultMessages.running,
+				done: cfgMessages.done ?? defaultMessages.done
+			}
+		} else {
+			return defaultMessages
+		}
+
 	}
 
 	public loadConfig(): void {


### PR DESCRIPTION
## Configuration for status messages

This PR introduces configuration options to provide custom status messages to be shown when Run On Save starts, finishes and individual commands are being run. I see multiple use cases for this feature. 

* More customizability
    * Allows users with small screens to shorten the status messages
    * Allows users to remove the status message shown when the commands have finished running 
* Better user feedback
    * The user getting feedback on how long a command takes relative to other ones
    * Progress-indication when multiple commands are being run (e.g. when an external formatter or linter has run)

All new configuration options are optional. This PR retains the old status messages as the default.

## Examples

### Simple

To show the functionality by example: This will show `Starting to sleep...` for one second, `I am sleeping again!` for another second and finally `Done sleeping!`. Technically, `Starting to sleep...` could have been the `message` for the first command to achieve identical behavior.

````
"emeraldwalk.runonsave": {
    "messages": {
        "running": "Starting to sleep...",
        "done": "Done sleeping!"
    },
    "commands": [
        {
            "cmd": "sleep 1",
        },
        {
            "cmd": "sleep 1",
            "message": "I am sleeping again!"
        }
    ]
}
````

### Empty idle message

This example shows a status message when a Ctags generator for Haskell files is being run and shows nothing otherwise.

````
"emeraldwalk.runonsave": {
    "messages": {
        "running": "",
        "done": "",
    },
    "commands": [
        {
            "match": ".hs",
            "cmd": "/root/.local/bin/hasktags -c /workspace/src/",
            "message": "Running hasktags..."
        }
    ]
}
````

