### PR TITLE
Automatically show output panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ Add "emeraldwalk.runonsave" configuration to user or workspace settings.
   - `message` - Message to output before this command.
   - `messageAfter` - Message to output after this command has finished.
   - `showElapsed` - Show total elapsed time after this command.
+  - `autoShowOutputPanel` - Automatically shows the output panel:
+    - `never` - Never changes the output panel visibility (default).
+    - `always` - Shows output panel when the first command starts.
+    - `error` - Shows output panel when a command fails.
 
 ### Notes on RegEx Options
 

--- a/package.json
+++ b/package.json
@@ -113,6 +113,16 @@
                     "type": "boolean",
                     "description": "Print elapsed time for the command.",
                     "default": false
+                  },
+                  "autoShowOutputPanel": {
+                    "description": "Automatically shows the output panel.",
+                    "type": "string",
+                    "default": "never",
+                    "enum": [
+                      "never",
+                      "always",
+                      "error"
+                    ]
                   }
                 }
               }

--- a/src/model.ts
+++ b/src/model.ts
@@ -9,10 +9,16 @@ export interface ICommand extends IMessageConfig {
   notMatch?: string;
   cmd?: string;
   isAsync: boolean;
+  autoShowOutputPanel?: "always" | "error" | "never";
 }
 
 export interface IConfig extends IMessageConfig {
   shell: string;
   autoClearConsole: boolean;
   commands: Array<ICommand>;
+}
+
+export interface IExecResult {
+  statusCode: number,
+  elapsedMs: number,
 }


### PR DESCRIPTION
Implements spec from #104.

Allows user to specify, per command, wether they want to show the output panel or not.

Adds the following new setting:
```
- ...
- `commands`
  - `autoShowOutputPanel` - Automatically shows the output panel:
    - `never` - Never changes the output panel visibility (default).
    - `always` - Shows output panel when the first command starts.
    - `error` - Shows output panel when a command fails.
    - ...
```

Example usage on vscode `settings.json`:
```
  "emeraldwalk.runonsave": {
    "commands": [
      {
        "cmd": "pwd",
        "autoShowOutputPanel": "always"
      }
    ]
  }
```