### PR TITLE
feat: summary status bar and improve process handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Add "emeraldwalk.runonsave" configuration to user or workspace settings.
   - `match` - a regex for matching which files to run commands on (see [Notes on RegEx Options](#notes-on-regex-options)).
   - `notMatch` - a regex for matching which files **NOT** to run. Files that match this pattern take precedence over ones that match the `match` option (see [Notes on RegEx Options](#notes-on-regex-options)).
   - `cmd` - command to run. Can include parameters that will be replaced at runtime (see Placeholder Tokens section below).
-  - `isAsync` (optional) - defaults to false, meaning that the command wait in a FIFO queue while other synchronous commands are being processed one at a time. If true, next command will be run before this one finishes.
+  - `isAsync` (optional) - defaults to false, meaning that the command waits in a FIFO queue while other synchronous commands are being processed one at a time. If true, next command will be run before this one finishes.
   - `killSignal` (optional) - the UNIX signal to send when killing the process. Allowed values are `SIGTERM` (default), `SIGINT`, and `SIGKILL`.
   - `message` - Message to output before this command.
   - `messageAfter` - Message to output after this command has finished.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,25 @@ NOTE: Commands only get run when saving an existing file. Creating new files, an
 
 - Configure multiple commands that run when a file is saved
 - Regex pattern matching for files that trigger commands running
-- Sync and async support
+- Synchronous and asynchronous command support
+  - Synchronous commands are executed one at a time in FIFO order.
+  - Asynchronous commands are executed immediately.
+
+## `Run On Save Status` status bar
+
+The `Run On Save Status` status bar summarizes the extension's state and number of running commands. Clicking the status bar reveals the `Run On Save` output channel.
+
+The text in the status bar is of the format `<state> Sync: <num-sync> Async: <num-async>` with values:
+
+- `<state>`:
+  - `idle` - extension is enabled with no commands running.
+  - `running` extension is enabled with at least one command is running.
+  - `draining` - extension is disabled with an unfinished sync and/or async command
+  - `disabled` - extension is disabled.
+- `<num-sync>` - the number of unfinished synchronous commands. One command will be executed at a time, and the remainder are queued.
+- `<num-async>` - the number of unfinished synchronous commands. Asynchronous commands are active processes.
+
+Clicking the status bar item reveals the `Run On Save` output channel.
 
 ## Configuration
 
@@ -23,7 +41,8 @@ Add "emeraldwalk.runonsave" configuration to user or workspace settings.
   - `match` - a regex for matching which files to run commands on (see [Notes on RegEx Options](#notes-on-regex-options)).
   - `notMatch` - a regex for matching which files **NOT** to run. Files that match this pattern take precedence over ones that match the `match` option (see [Notes on RegEx Options](#notes-on-regex-options)).
   - `cmd` - command to run. Can include parameters that will be replaced at runtime (see Placeholder Tokens section below).
-  - `isAsync` (optional) - defaults to false. If true, next command will be run before this one finishes.
+  - `isAsync` (optional) - defaults to false, meaning that the command wait in a FIFO queue while other synchronous commands are being processed one at a time. If true, next command will be run before this one finishes.
+  - `killSignal` (optional) - the UNIX signal to send when killing the process. Allowed values are `SIGTERM` (default), `SIGINT`, and `SIGKILL`.
   - `message` - Message to output before this command.
   - `messageAfter` - Message to output after this command has finished.
   - `showElapsed` - Show total elapsed time after this command.
@@ -184,14 +203,15 @@ The `match` and `notMatch` options expect RegEx patterns.
 
 ## Output of the commands
 
-Please see the output in Output window and then switch the right side drop down to "Run On Save" to see the ouput of the commands stdout
+The stdout for commands can be found in the `Run On Save` extension output, accessed via the `Run On Save: Show Output Channel` command.
 
 ## Commands
 
 The following commands are exposed in the command palette:
 
-- On Save: Enable
-- On Save: Disable
+- `Run On Save: Enable` - Enables the extension.
+- `Run On Save: Disable` - Disables the extension, terminates all running command processes using their `killSignal`, and clears queue of unprocessed synchronous commands.
+- `Run On Save: Show Output Channel` - Reveals the extension's output channel.
 
 ## Placeholder Tokens
 

--- a/README.md
+++ b/README.md
@@ -9,22 +9,23 @@ NOTE: Commands only get run when saving an existing file. Creating new files, an
 - Configure multiple commands that run when a file is saved
 - Regex pattern matching for files that trigger commands running
 - Synchronous and asynchronous command support
-  - Synchronous commands are executed one at a time in FIFO order.
-  - Asynchronous commands are executed immediately.
+  - Synchronous (sequential) commands are executed one at a time in FIFO order.
+  - Asynchronous (parallel) commands allow the next command to start before completing.
 
 ## `Run On Save Status` status bar
 
 The `Run On Save Status` status bar summarizes the extension's state and number of running commands. Clicking the status bar reveals the `Run On Save` output channel.
 
-The text in the status bar is of the format `<state> Sync: <num-sync> Async: <num-async>` with values:
+The text in the status bar is of the format `<state-icon> Q:<num-queued>,S:<num-sequential>,P:<num-parallel>` with values:
 
 - `<state>`:
-  - `idle` - extension is enabled with no commands running.
-  - `running` extension is enabled with at least one command is running.
-  - `draining` - extension is disabled with an unfinished sync and/or async command
-  - `disabled` - extension is disabled.
-- `<num-sync>` - the number of unfinished synchronous commands. One command will be executed at a time, and the remainder are queued.
-- `<num-async>` - the number of unfinished synchronous commands. Asynchronous commands are active processes.
+  - `Idle` - extension is enabled with no commands running.
+  - `Running` extension is enabled with at least one command is running.
+  - `Draining` - extension is disabled with an unfinished sync and/or async command
+  - `Disabled` - extension is disabled.
+- `<num-queued>` - the number of commands that have not yet been started.
+- `<num-sequential>` - the number of active sequential commands.
+- `<num-parallel>` - the number of active parallel (asynchronous) commands.
 
 Clicking the status bar item reveals the `Run On Save` output channel.
 

--- a/package.json
+++ b/package.json
@@ -46,6 +46,10 @@
       {
         "command": "extension.emeraldwalk.disableRunOnSave",
         "title": "Run On Save: Disable"
+      },
+      {
+        "command": "extension.emeraldwalk.showOutputChannel",
+        "title": "Run On Save: Show Output Channel"
       }
     ],
     "configuration": {
@@ -122,6 +126,16 @@
                       "never",
                       "always",
                       "error"
+                    ]
+                  },
+                  "killSignal": {
+                    "type": "string",
+                    "description": "The UNIX signal to use when killing the process. Allowed values are 'SIGTERM' or 'SIGKILL'.",
+                    "default": "SIGTERM",
+                    "enum": [
+                      "SIGTERM",
+                      "SIGINT",
+                      "SIGKILL"
                     ]
                   }
                 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -189,27 +189,27 @@ class RunOnSaveExtension implements vscode.Disposable {
     this._commandAbortController = new AbortController();
   }
 
-  public enable(): void {
+  public async enable(): Promise<void> {
     if (this.isEnabled()) {
       // Already enabled.
       return;
     }
 
-    this._context.globalState.update('isEnabled', true).then(() => {
-      // Start the synchronous command runner loop.
-      this.showOutputMessage();
-      this.refreshStatus();
-    });
+    await this._context.globalState.update('isEnabled', true);
+
+    // Start the synchronous command runner loop.
+    this.showOutputMessage();
+    this.refreshStatus();
   }
 
-  public disable(): void {
-    this._context.globalState.update('isEnabled', false).then(() => {
-      this.showOutputMessage("Disabling Run On Save. Aborting all running commands and purging queue.");
-      this._abortAllRunningCommands();
+  public async disable(): Promise<void> {
+    await this._context.globalState.update('isEnabled', false);
 
-      // Refresh the status bar.
-      this.refreshStatus();
-    });
+    this.showOutputMessage("Disabling Run On Save. Aborting all running commands and purging queue.");
+    this._abortAllRunningCommands();
+
+    // Refresh the status bar.
+    this.refreshStatus();
   }
 
   public isEnabled(): boolean {

--- a/src/model.ts
+++ b/src/model.ts
@@ -18,6 +18,9 @@ export interface ICommand extends IMessageConfig {
   cmd?: string;
   isAsync: boolean;
   autoShowOutputPanel?: "always" | "error" | "never";
+
+  // The UNIX signal to use when killing the process. Allowed values are `SIGTERM` (the default), `SIGINT`, or `SIGKILL`.
+  killSignal?: 'SIGTERM' | 'SIGINT' | 'SIGKILL';
 }
 
 export interface IConfig extends IMessageConfig {

--- a/src/model.ts
+++ b/src/model.ts
@@ -33,3 +33,11 @@ export interface IExecResult {
   statusCode: number,
   elapsedMs: number,
 }
+
+export interface RunCommandConfig {
+  cfg: ICommand;
+  // The modified saved document or notebook that triggered command execution.
+  document: Document;
+  // Callback to invoke when the command finishes execution (successfully or not).
+  finishCallback: () => void;
+}


### PR DESCRIPTION
This PR started with a desire to add a summary status bar, but I quickly found some improvements were required to command handling to make that happen.

- Improves visibility into the state of the extension by adding a `Run On Save Status` status bar. Text of  `running Sync: 3 Async: 2` indicates that the extension is currently running 3 synchronous and 2 async commands. Text of `idle Sync: 0 Async: 0` indicates that nothing is currently running.
    - Clicking the status bar reveals the Run On Save output.
 - Removes vestigial status bar code that stopped working a long time ago.
- Improves synchronous command handling:
  - Sync commands are processed one at a time in FIFO order. Prior to this change, saving 20 files at the same time (like with a search/replace) would lead to 20 separate sync commands being run simultaneously. With this change, the 20 commands would be executed one at a time.
- When disabled, terminates all running commands. This provides a much-needed means to terminate commands when things have gone awry.
  - The signal used to kill the processes is controlled via command's `killSignal` property, defaulting to `SIGTERM`.

## Description of Changes
Summarize changes this PR introduces.

## Testing

### Poke around with the status bar.

Have run on save config, verify that the status bar displays expected information.

### Verify disabling extension terminates running commands.
The following command will spawn sync and async commands, each starting a "sleep":

```jsonc
{
  "emeraldwalk.runonsave": {
    "commands": [
      {
        "match": ".*",
        "cmd": "sleep 99999"
      },
      {
        "match": ".*",
        "cmd": "sleep 88888",
        "isAsync": true
      }
    ]
  }
}
```

1. Save several files
2. Observe that the number of sync and async commands have counted upward.
3. run `ps aux| grep sleep` and observe the accumulation of a `sleep 99999` sync command and several `sleep 88888` async commands.
4. Run the `Run On Save: Disable` command.
5. Observe that the processes have been terminated and the queue cleared.

## Checklist
- [x] Did you update any relevant docs / samples?
- [x] Did you include details on how to test your changes?
